### PR TITLE
First two songs inside info.items

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ const { getInfo } = require('ytdl-getinfo')
   ```javascript
   getInfo('PLwiyx1dc3P2JR9N8gQaQN_BCvlSlap7re').then(info => {
     // info.partial is true for playlists
+    // And first two songs are in info.items from start
     if (info.partial) {
       info.on('video', v => console.log(v.title))
       info.on('done', () => console.log(`Playlist contains ${info.items.length} items.`))


### PR DESCRIPTION
The first two songs from the playlist are not getting sent as on video which so I would recommend adding that to documentations.
Already caused issue report #4 and I have found myself looking at what is causing this too.